### PR TITLE
Add CSV bulk import wizard for PMKSY datasets

### DIFF
--- a/pmksy_wizard/README.md
+++ b/pmksy_wizard/README.md
@@ -7,6 +7,7 @@ This Django project implements a multi-step data collection wizard for the PMKSY
 - Dynamic formsets for repeated sections such as land holdings, assets, crop history, cost of cultivation and more.
 - SQLite database configuration out of the box with admin registrations for all models.
 - Responsive UI with progressive enhancement for adding formset rows without reloading.
+- CSV-driven bulk import wizard for ingesting data that already exists in spreadsheets following the PMKSY schema.
 
 ## Getting started
 1. Install dependencies (requires Python 3.11):
@@ -22,6 +23,14 @@ This Django project implements a multi-step data collection wizard for the PMKSY
    python manage.py runserver 0.0.0.0:8000
    ```
 4. Open `http://localhost:8000/` to use the wizard. Django admin is available at `http://localhost:8000/admin/`.
+
+## Bulk import workflow
+- Navigate to **Bulk import** from the header to launch the CSV wizard.
+- Select the target dataset (e.g. Farmers, Land Holdings) and upload a UTF-8 CSV with headers that match the
+  column names in `pmksy_schema.md`. When importing related tables, ensure each row includes the `farmer_id` of an existing
+  farmer record.
+- Review the automatic column matching, preview the first few rows and confirm the import. Validation errors are reported
+  with row numbers so that source files can be amended before retrying.
 
 ## Data model
 The models mirror the normalised tables described in `pmksy_schema.md`, covering farmer demographics, holdings, inputs, income sources, adaptation strategies and financial inclusion indicators.

--- a/pmksy_wizard/pmksy/forms.py
+++ b/pmksy_wizard/pmksy/forms.py
@@ -227,6 +227,28 @@ class IrrigatedRainfedForm(forms.ModelForm):
         for field in self.fields.values():
             field.required = False
 
+
+class ImportUploadForm(forms.Form):
+    """Initial step of the bulk import wizard."""
+
+    target = forms.ChoiceField(label="Dataset", help_text="Select the table you want to import data into.")
+    data_file = forms.FileField(
+        label="Data file",
+        help_text="Upload a UTF-8 CSV file. Column headers should match the PMKSY schema names.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        choices = kwargs.pop("choices", ())
+        super().__init__(*args, **kwargs)
+        self.fields["target"].choices = list(choices)
+
+    def clean_data_file(self):
+        uploaded = self.cleaned_data.get("data_file")
+        if uploaded and uploaded.size == 0:
+            raise forms.ValidationError("The selected file is empty.")
+        return uploaded
+
+
 LandHoldingFormSet = forms.formset_factory(LandHoldingForm, extra=1, can_delete=True)
 AssetFormSet = forms.formset_factory(AssetForm, extra=1, can_delete=True)
 CropHistoryFormSet = forms.formset_factory(CropHistoryForm, extra=1, can_delete=True)

--- a/pmksy_wizard/pmksy/importers.py
+++ b/pmksy_wizard/pmksy/importers.py
@@ -1,0 +1,478 @@
+"""Utility classes and helpers to power the CSV bulk import wizard."""
+from __future__ import annotations
+
+import csv
+import io
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Mapping, Sequence
+
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import IntegrityError, models, transaction
+from django.utils.text import capfirst
+
+from . import models as pmksy_models
+
+EMPTY_STRINGS = {"", "na", "n/a", "null", "none", "nil", "nan"}
+BOOLEAN_TRUE = {"true", "1", "yes", "y", "t"}
+BOOLEAN_FALSE = {"false", "0", "no", "n", "f"}
+MAX_ERRORS_REPORTED = 50
+
+
+@dataclass(frozen=True)
+class ImportTarget:
+    """Describes a dataset that can be imported through the wizard."""
+
+    key: str
+    label: str
+    description: str
+    model: type[models.Model]
+    field_map: Mapping[str, str]
+    required_columns: Sequence[str] = field(default_factory=tuple)
+
+    def humanised_column(self, column: str) -> str:
+        """Return a readable name for a column."""
+
+        field_name = self.field_map.get(column, column)
+        try:
+            field = self.model._meta.get_field(field_name)
+        except Exception:  # pragma: no cover - defensive
+            return capfirst(column.replace("_", " "))
+
+        label = field.verbose_name or field_name
+        if isinstance(field, models.ForeignKey) and column.endswith("_id"):
+            return capfirst(f"{label} id")
+        return capfirst(label)
+
+    @property
+    def expected_columns(self) -> List[str]:
+        return list(self.field_map.keys())
+
+    @property
+    def required(self) -> set[str]:
+        return set(self.required_columns)
+
+
+@dataclass
+class ParsedRow:
+    """A single row parsed from an uploaded file."""
+
+    line_number: int
+    values: Dict[str, str]
+
+
+@dataclass
+class ParsedDataset:
+    """Result of parsing an uploaded CSV file."""
+
+    columns: List[str]
+    original_headers: Dict[str, str]
+    rows: List[ParsedRow]
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+@dataclass
+class RowError:
+    """Information about a row that failed to import."""
+
+    row_number: int
+    message: str
+    values: Mapping[str, str]
+
+
+@dataclass
+class ImportSummary:
+    """Summary statistics returned after attempting an import."""
+
+    total_rows: int
+    created: int
+    skipped: int
+    errors: List[RowError]
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+
+def build_field_map(model: type[models.Model]) -> Dict[str, str]:
+    """Derive a mapping of CSV columns → model field names for a model."""
+
+    mapping: Dict[str, str] = {}
+    for field in model._meta.get_fields():
+        if not getattr(field, "concrete", False):
+            continue
+        if getattr(field, "auto_created", False):
+            continue
+        if isinstance(field, models.ForeignKey):
+            mapping[f"{field.name}_id"] = field.name
+        else:
+            mapping[field.name] = field.name
+    return mapping
+
+
+TARGET_DEFINITIONS: Sequence[tuple[str, str, str, type[models.Model], Sequence[str]]] = [
+    (
+        "farmers",
+        "Farmers (Basic Profile)",
+        "Create farmer records with demographic and household level attributes.",
+        pmksy_models.Farmer,
+        ("name",),
+    ),
+    (
+        "land_holdings",
+        "Land Holdings",
+        "Attach land parcel information to an existing farmer via farmer_id.",
+        pmksy_models.LandHolding,
+        ("farmer_id",),
+    ),
+    (
+        "assets",
+        "Assets",
+        "Bulk upload asset ownership for farmers.",
+        pmksy_models.Asset,
+        ("farmer_id", "item_name"),
+    ),
+    (
+        "crop_history",
+        "Crop History",
+        "Historical crop production information.",
+        pmksy_models.CropHistory,
+        ("farmer_id", "crop_name"),
+    ),
+    (
+        "cost_of_cultivation",
+        "Cost of Cultivation",
+        "Cost inputs for crop cultivation.",
+        pmksy_models.CostOfCultivation,
+        ("farmer_id", "crop_name", "particular"),
+    ),
+    (
+        "weed_records",
+        "Weeds",
+        "Weed management records, linked to an existing farmer.",
+        pmksy_models.WeedRecord,
+        ("farmer_id",),
+    ),
+    (
+        "water_management",
+        "Water Management",
+        "Water management practices including irrigation counts and costs.",
+        pmksy_models.WaterManagement,
+        ("farmer_id",),
+    ),
+    (
+        "pest_disease",
+        "Pest & Disease",
+        "Pest and disease management entries for a farmer.",
+        pmksy_models.PestDiseaseRecord,
+        ("farmer_id", "pest_disease"),
+    ),
+    (
+        "nutrient_management",
+        "Nutrient Management",
+        "Fertiliser and nutrient application by crop and season.",
+        pmksy_models.NutrientManagement,
+        ("farmer_id", "crop_name"),
+    ),
+    (
+        "income_from_crops",
+        "Income from Crops",
+        "Income realisation per crop and season.",
+        pmksy_models.IncomeFromCrops,
+        ("farmer_id", "crop_name"),
+    ),
+    (
+        "enterprises",
+        "Enterprises",
+        "Allied enterprises and diversification activities.",
+        pmksy_models.Enterprise,
+        ("farmer_id", "enterprise_type"),
+    ),
+    (
+        "annual_family_income",
+        "Annual Family Income",
+        "Annual income from different livelihood sources.",
+        pmksy_models.AnnualFamilyIncome,
+        ("farmer_id", "source"),
+    ),
+    (
+        "migration",
+        "Migration",
+        "Migration details for household members.",
+        pmksy_models.MigrationRecord,
+        ("farmer_id", "age_gender"),
+    ),
+    (
+        "adaptation_strategies",
+        "Adaptation Strategies",
+        "Climate adaptation strategies known or adopted.",
+        pmksy_models.AdaptationStrategy,
+        ("farmer_id", "strategy"),
+    ),
+    (
+        "financials",
+        "Financial Records",
+        "Financial inclusion, credit and benefit utilisation.",
+        pmksy_models.FinancialRecord,
+        ("farmer_id",),
+    ),
+    (
+        "consumption_pattern",
+        "Consumption Pattern",
+        "Monthly consumption of agricultural produce.",
+        pmksy_models.ConsumptionPattern,
+        ("farmer_id", "crop"),
+    ),
+    (
+        "market_price",
+        "Market Price",
+        "Market price realisation for crops.",
+        pmksy_models.MarketPrice,
+        ("farmer_id", "crop"),
+    ),
+    (
+        "irrigated_rainfed",
+        "Irrigated & Rainfed",
+        "Split irrigated versus rainfed crop areas.",
+        pmksy_models.IrrigatedRainfed,
+        ("farmer_id", "crop"),
+    ),
+]
+
+IMPORT_TARGETS: Dict[str, ImportTarget] = {}
+TARGET_LIST: List[ImportTarget] = []
+
+for key, label, description, model, required_cols in TARGET_DEFINITIONS:
+    target = ImportTarget(
+        key=key,
+        label=label,
+        description=description,
+        model=model,
+        field_map=build_field_map(model),
+        required_columns=required_cols,
+    )
+    IMPORT_TARGETS[key] = target
+    TARGET_LIST.append(target)
+
+
+def get_target(key: str) -> ImportTarget:
+    """Retrieve the ImportTarget for a given key."""
+
+    if key not in IMPORT_TARGETS:
+        raise KeyError(f"Unknown import target '{key}'")
+    return IMPORT_TARGETS[key]
+
+
+def target_choices() -> List[tuple[str, str]]:
+    """Return choices suitable for populating a form field."""
+
+    return [(target.key, target.label) for target in TARGET_LIST]
+
+
+def normalise_header(header: str) -> str:
+    """Normalise header names to snake_case for matching."""
+
+    cleaned = re.sub(r"[^0-9a-zA-Z]+", "_", header or "")
+    cleaned = cleaned.strip("_").lower()
+    return cleaned
+
+
+def parse_uploaded_file(uploaded_file) -> ParsedDataset:
+    """Parse an uploaded CSV file into structured rows."""
+
+    raw_bytes = uploaded_file.read()
+    if not raw_bytes:
+        raise ValueError("The uploaded file is empty.")
+
+    try:
+        decoded = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Unable to decode file as UTF-8.") from exc
+
+    stream = io.StringIO(decoded)
+    sample = decoded[:1024]
+    try:
+        dialect = csv.Sniffer().sniff(sample)
+    except csv.Error:
+        dialect = csv.excel
+
+    reader = csv.DictReader(stream, dialect=dialect)
+    if not reader.fieldnames:
+        raise ValueError("The file does not contain a header row.")
+
+    header_map = {original: normalise_header(original) for original in reader.fieldnames if original is not None}
+    normalised_to_original = {normal: original for original, normal in header_map.items()}
+    columns = list(normalised_to_original.keys())
+
+    rows: List[ParsedRow] = []
+    for index, raw_row in enumerate(reader, start=2):
+        normalised_row: Dict[str, str] = {}
+        meaningful = False
+        for original, normalised in header_map.items():
+            value = raw_row.get(original, "")
+            if value is None:
+                value = ""
+            value = value.strip()
+            if value:
+                meaningful = True
+            normalised_row[normalised] = value
+        if not meaningful:
+            continue
+        rows.append(ParsedRow(line_number=index, values=normalised_row))
+
+    if not rows:
+        raise ValueError("No data rows were detected in the uploaded file.")
+
+    return ParsedDataset(columns=columns, original_headers=normalised_to_original, rows=rows)
+
+
+def is_empty(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        value = value.strip()
+        return value.lower() in EMPTY_STRINGS if value else True
+    return False
+
+
+def parse_boolean(value: str) -> bool:
+    lowered = value.lower()
+    if lowered in BOOLEAN_TRUE:
+        return True
+    if lowered in BOOLEAN_FALSE:
+        return False
+    raise ValueError(f"Cannot interpret '{value}' as a boolean")
+
+
+def parse_decimal(value: str) -> Decimal:
+    try:
+        cleaned = value.replace(",", "")
+        return Decimal(cleaned)
+    except InvalidOperation as exc:
+        raise ValueError(f"Cannot interpret '{value}' as a decimal") from exc
+
+
+def parse_date(value: str):
+    for fmt in ("%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse '{value}' as a date (expected YYYY-MM-DD)")
+
+
+def convert_value(field: models.Field, value: str):
+    if isinstance(field, models.BooleanField):
+        return parse_boolean(value)
+    if isinstance(field, models.UUIDField):
+        return uuid.UUID(value)
+    if isinstance(field, models.DecimalField):
+        return parse_decimal(value)
+    if isinstance(field, (models.IntegerField, models.AutoField)):
+        return int(value)
+    if isinstance(field, models.FloatField):
+        return float(value)
+    if isinstance(field, models.DateField):
+        return parse_date(value)
+    return value
+
+
+def prepare_row(target: ImportTarget, row: Mapping[str, str]) -> Dict[str, object] | None:
+    """Convert a normalised CSV row into model keyword arguments."""
+
+    if all(is_empty(value) for value in row.values()):
+        return None
+
+    for required in target.required:
+        if is_empty(row.get(required)):
+            raise ValueError(f"Missing value for required column '{required}'")
+
+    cleaned: Dict[str, object] = {}
+    for column, field_name in target.field_map.items():
+        if column not in row:
+            continue
+        raw_value = row[column]
+        if is_empty(raw_value):
+            continue
+        field = target.model._meta.get_field(field_name)
+        if isinstance(field, models.ForeignKey):
+            related_field = field.target_field
+            try:
+                related_value = convert_value(related_field, raw_value)
+            except Exception as exc:  # pragma: no cover - handled via ValueError
+                raise ValueError(str(exc)) from exc
+            try:
+                related_obj = field.remote_field.model.objects.get(
+                    **{related_field.attname: related_value}
+                )
+            except ObjectDoesNotExist as exc:
+                raise ValueError(
+                    f"Related {field.remote_field.model.__name__} with {related_field.attname}={raw_value} not found"
+                ) from exc
+            cleaned[field.name] = related_obj
+            continue
+        try:
+            cleaned[field.name] = convert_value(field, raw_value)
+        except ValueError as exc:
+            raise ValueError(f"Column '{column}': {exc}") from exc
+    return cleaned
+
+
+def perform_import(target: ImportTarget, parsed_rows: Sequence[ParsedRow]) -> ImportSummary:
+    """Execute the import and return summary statistics."""
+
+    created = 0
+    skipped = 0
+    errors: List[RowError] = []
+
+    for parsed_row in parsed_rows:
+        row_number = parsed_row.line_number
+        values = parsed_row.values
+        try:
+            payload = prepare_row(target, values)
+        except ValueError as exc:
+            if len(errors) < MAX_ERRORS_REPORTED:
+                errors.append(RowError(row_number=row_number, message=str(exc), values=dict(values)))
+            continue
+
+        if not payload:
+            skipped += 1
+            continue
+
+        try:
+            with transaction.atomic():
+                instance = target.model(**payload)
+                instance.full_clean()
+                instance.save()
+        except (ValidationError, IntegrityError) as exc:
+            message = format_validation_error(exc)
+            if len(errors) < MAX_ERRORS_REPORTED:
+                errors.append(RowError(row_number=row_number, message=message, values=dict(values)))
+        else:
+            created += 1
+
+    return ImportSummary(
+        total_rows=len(parsed_rows),
+        created=created,
+        skipped=skipped,
+        errors=errors,
+    )
+
+
+def format_validation_error(error: Exception) -> str:
+    if isinstance(error, ValidationError):
+        if hasattr(error, "message_dict"):
+            parts = []
+            for field, messages in error.message_dict.items():
+                joined = ", ".join(messages)
+                parts.append(f"{field}: {joined}")
+            return "; ".join(parts)
+        return ", ".join(error.messages)
+    return str(error)
+

--- a/pmksy_wizard/pmksy/static/pmksy/css/styles.css
+++ b/pmksy_wizard/pmksy/static/pmksy/css/styles.css
@@ -37,6 +37,26 @@ body {
   color: #475569;
 }
 
+.app-nav {
+  margin-top: 1rem;
+  display: inline-flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.app-nav a {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--primary);
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(20, 184, 166, 0.12);
+}
+
+.app-nav a:hover {
+  background: rgba(20, 184, 166, 0.24);
+}
+
 .app-footer {
   margin-top: 3rem;
   background: white;
@@ -100,6 +120,18 @@ form {
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: 0 10px 40px rgba(15, 23, 42, 0.06);
+}
+
+form.plain-form {
+  display: inline;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+form.plain-form button {
+  margin: 0;
 }
 
 .form-section + .form-section {
@@ -305,6 +337,38 @@ form {
 
 .summary-table tr:nth-child(even) {
   background: #f8fafc;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+}
+
+.table-wrapper table {
+  margin-bottom: 0;
+  border: none;
+}
+
+.error-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.error-list .summary-card {
+  background: #fff5f5;
+  border-color: #fecaca;
+}
+
+.error-list .summary-card h4 {
+  margin-top: 0;
+}
+
+.error-list .summary-card ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1rem;
 }
 
 @media (max-width: 640px) {

--- a/pmksy_wizard/pmksy/templates/pmksy/base.html
+++ b/pmksy_wizard/pmksy/templates/pmksy/base.html
@@ -15,6 +15,10 @@
         <p class="lead">
           A guided workflow to capture farmer socio-economic indicators following the PMKSY schema.
         </p>
+        <nav class="app-nav">
+          <a href="{% url 'pmksy:wizard' %}">Manual entry</a>
+          <a href="{% url 'pmksy:import' %}">Bulk import</a>
+        </nav>
       </div>
     </header>
     <main class="container">

--- a/pmksy_wizard/pmksy/templates/pmksy/import_wizard_preview.html
+++ b/pmksy_wizard/pmksy/templates/pmksy/import_wizard_preview.html
@@ -1,0 +1,164 @@
+{% extends "pmksy/base.html" %}
+{% block title %}Import preview · PMKSY Survey Wizard{% endblock %}
+{% block content %}
+  <section class="wizard-status">
+    <div class="step-heading">
+      <h2>{{ target.label }}</h2>
+      <p>{{ target.description }}</p>
+    </div>
+    <div class="summary-grid">
+      <div class="summary-card">
+        <h3>Total rows detected</h3>
+        <p><strong>{{ row_count }}</strong></p>
+      </div>
+      <div class="summary-card">
+        <h3>Columns recognised</h3>
+        <p><strong>{{ recognized_columns|length }}</strong> of {{ column_order|length }}</p>
+      </div>
+      <div class="summary-card">
+        <h3>Required columns</h3>
+        <ul>
+          {% for label in required_columns %}
+            <li>{{ label }}</li>
+          {% empty %}
+            <li>No mandatory columns.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  {% if import_complete %}
+    <section class="completion">
+      <h3>Import summary</h3>
+      <table class="summary-table">
+        <tbody>
+          <tr>
+            <th>Total rows processed</th>
+            <td>{{ summary.total_rows }}</td>
+          </tr>
+          <tr>
+            <th>Rows created</th>
+            <td>{{ summary.created }}</td>
+          </tr>
+          <tr>
+            <th>Rows skipped (empty)</th>
+            <td>{{ summary.skipped }}</td>
+          </tr>
+          <tr>
+            <th>Errors</th>
+            <td>{{ summary.error_count }}</td>
+          </tr>
+        </tbody>
+      </table>
+      {% if summary.errors %}
+        <h4>Rows with issues</h4>
+      <p class="section-help">Only the first {{ error_rows|length }} errors are shown.</p>
+        <div class="error-list">
+          {% for error in error_rows %}
+            <article class="summary-card">
+              <h4>Row {{ error.row_number }}</h4>
+              <p class="section-help">{{ error.message }}</p>
+              <ul>
+                {% for label, value in error.values %}
+                  <li><strong>{{ label }}:</strong> {{ value }}</li>
+                {% endfor %}
+              </ul>
+            </article>
+          {% endfor %}
+        </div>
+      {% endif %}
+      <div class="wizard-actions">
+        <a class="primary" href="{% url 'pmksy:import' %}">Import another file</a>
+        <a class="secondary" href="{% url 'pmksy:wizard' %}">Back to manual entry</a>
+      </div>
+    </section>
+  {% else %}
+    <section class="completion">
+      {% if missing_columns %}
+        <div class="message error">
+          <strong>Missing required columns:</strong>
+          <ul>
+            {% for label in missing_columns %}
+              <li>{{ label }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+      {% if unused_columns %}
+        <div class="message">
+          <strong>Unrecognised columns:</strong>
+          <ul>
+            {% for label in unused_columns %}
+              <li>{{ label }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+      <h3>Column mapping</h3>
+      <table class="summary-table">
+        <thead>
+          <tr>
+            <th>File header</th>
+            <th>Model field</th>
+            <th>PMKSY column</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for column in recognized_columns %}
+            <tr>
+              <td>{{ column.source }}</td>
+              <td><code>{{ column.model_field }}</code></td>
+              <td>{{ column.model_label }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="3">No matching columns were detected.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <h3>Data preview</h3>
+      <p class="section-help">Showing the first {{ preview_table|length }} rows.</p>
+      <div class="table-wrapper">
+        <table class="summary-table">
+          <thead>
+            <tr>
+              {% for header in preview_headers %}
+                <th>{{ header.label }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in preview_table %}
+              <tr>
+                {% for value in row %}
+                  <td>{{ value }}</td>
+                {% endfor %}
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="{{ preview_headers|length }}">No sample rows available.</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="wizard-actions">
+        {% if can_import %}
+          <form method="post" class="plain-form">
+            {% csrf_token %}
+            <input type="hidden" name="confirm" value="1" />
+            <button type="submit" class="primary">Import {{ target.label }}</button>
+          </form>
+        {% else %}
+          <button type="button" class="primary" disabled>Resolve issues to import</button>
+        {% endif %}
+        <form method="post" class="plain-form">
+          {% csrf_token %}
+          <button type="submit" name="cancel" value="1" class="secondary">Cancel import</button>
+        </form>
+      </div>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/pmksy_wizard/pmksy/templates/pmksy/import_wizard_upload.html
+++ b/pmksy_wizard/pmksy/templates/pmksy/import_wizard_upload.html
@@ -1,0 +1,65 @@
+{% extends "pmksy/base.html" %}
+{% block title %}Bulk import · PMKSY Survey Wizard{% endblock %}
+{% block content %}
+  <section class="wizard-status">
+    <h2>Bulk data import</h2>
+    <p>
+      Upload CSV files that follow the <strong>PMKSY socio-economic schema</strong> to create records in bulk.
+      Each dataset expects column headers that match the field names listed in
+      <code>pmksy_schema.md</code>.
+    </p>
+  </section>
+
+  <section class="completion">
+    <h3>Available datasets</h3>
+    <p class="section-help">
+      Every import links rows to a farmer using the <code>farmer_id</code> column when required. Start with the
+      farmer profile before importing linked tables.
+    </p>
+    <div class="summary-grid">
+      {% for target in targets %}
+        <article class="summary-card">
+          <h4>{{ target.label }}</h4>
+          <p>{{ target.description }}</p>
+        </article>
+      {% endfor %}
+    </div>
+  </section>
+
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+      <div class="message error">
+        {% for error in form.non_field_errors %}
+          <p>{{ error }}</p>
+        {% endfor %}
+      </div>
+    {% endif %}
+    <div class="form-grid">
+      <div class="form-field{% if form.target.errors %} has-error{% endif %}">
+        <label for="{{ form.target.id_for_label }}">{{ form.target.label }}</label>
+        {{ form.target }}
+        {% if form.target.help_text %}
+          <span class="help">{{ form.target.help_text }}</span>
+        {% endif %}
+        {% for error in form.target.errors %}
+          <span class="error">{{ error }}</span>
+        {% endfor %}
+      </div>
+      <div class="form-field{% if form.data_file.errors %} has-error{% endif %}">
+        <label for="{{ form.data_file.id_for_label }}">{{ form.data_file.label }}</label>
+        {{ form.data_file }}
+        {% if form.data_file.help_text %}
+          <span class="help">{{ form.data_file.help_text }}</span>
+        {% endif %}
+        {% for error in form.data_file.errors %}
+          <span class="error">{{ error }}</span>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="wizard-actions">
+      <button type="submit" class="primary">Continue to preview</button>
+      <a href="{% url 'pmksy:wizard' %}" class="secondary">Back to manual entry</a>
+    </div>
+  </form>
+{% endblock %}

--- a/pmksy_wizard/pmksy/tests.py
+++ b/pmksy_wizard/pmksy/tests.py
@@ -1,4 +1,74 @@
-"""Minimal tests placeholder for the PMKSY app."""
+"""Tests for the PMKSY wizard and bulk import workflow."""
 from __future__ import annotations
 
-# Add application tests here.
+import uuid
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from . import importers, models
+
+
+class BulkImportWizardTests(TestCase):
+    """Integration tests covering the CSV import wizard endpoints."""
+
+    def upload_csv(self, target: str, content: str) -> None:
+        file = SimpleUploadedFile("upload.csv", content.encode("utf-8"))
+        response = self.client.post(
+            reverse("pmksy:import"),
+            {"target": target, "data_file": file},
+            follow=False,
+        )
+        self.assertRedirects(response, reverse("pmksy:import-preview"))
+
+    def test_import_farmer_profile(self) -> None:
+        self.upload_csv("farmers", "name,district\nAsha,Solapur\n")
+
+        preview = self.client.get(reverse("pmksy:import-preview"))
+        self.assertContains(preview, "Total rows detected")
+        self.assertContains(preview, "Farmers (Basic Profile)")
+
+        confirm = self.client.post(reverse("pmksy:import-preview"), {"confirm": "1"})
+        self.assertContains(confirm, "Import summary")
+        self.assertEqual(models.Farmer.objects.count(), 1)
+        farmer = models.Farmer.objects.get()
+        self.assertEqual(farmer.name, "Asha")
+        self.assertEqual(farmer.district, "Solapur")
+
+    def test_import_land_holding(self) -> None:
+        farmer = models.Farmer.objects.create(name="Rahul")
+        csv = f"farmer_id,category,total_area_ha\n{farmer.farmer_id},Irrigated,2.5\n"
+        self.upload_csv("land_holdings", csv)
+
+        response = self.client.post(reverse("pmksy:import-preview"), {"confirm": "1"})
+        self.assertContains(response, "Import summary")
+        holding = models.LandHolding.objects.get()
+        self.assertEqual(str(holding.farmer.farmer_id), str(farmer.farmer_id))
+        self.assertEqual(holding.category, "Irrigated")
+
+    def test_missing_required_columns_blocks_import(self) -> None:
+        self.upload_csv("land_holdings", "category\nIrrigated\n")
+        preview = self.client.get(reverse("pmksy:import-preview"))
+        self.assertContains(preview, "Missing required columns")
+
+        response = self.client.post(reverse("pmksy:import-preview"), {"confirm": "1"})
+        self.assertContains(response, "Required columns are missing")
+        self.assertEqual(models.LandHolding.objects.count(), 0)
+
+
+class ImporterFunctionTests(TestCase):
+    """Lower level tests for the import helper functions."""
+
+    def test_perform_import_reports_missing_foreign_key(self) -> None:
+        target = importers.get_target("land_holdings")
+        rows = [
+            importers.ParsedRow(
+                line_number=2,
+                values={"farmer_id": str(uuid.uuid4()), "category": "Seasonal"},
+            )
+        ]
+        summary = importers.perform_import(target, rows)
+        self.assertEqual(summary.created, 0)
+        self.assertEqual(summary.error_count, 1)
+        self.assertIn("Related", summary.errors[0].message)

--- a/pmksy_wizard/pmksy/urls.py
+++ b/pmksy_wizard/pmksy/urls.py
@@ -10,4 +10,11 @@ app_name = "pmksy"
 urlpatterns = [
     path("", views.wizard_view, name="wizard"),
     path("step/<str:step>/", views.wizard_view, name="wizard-step"),
+    path("import/", views.bulk_import_wizard_view, name="import"),
+    path(
+        "import/preview/",
+        views.bulk_import_wizard_view,
+        {"step": "preview"},
+        name="import-preview",
+    ),
 ]

--- a/pmksy_wizard/pmksy/views.py
+++ b/pmksy_wizard/pmksy/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views import View
 
-from . import forms, models
+from . import forms, importers, models
 
 
 class SurveyWizardView(View):
@@ -285,3 +285,197 @@ class SurveyWizardView(View):
 
 
 wizard_view = SurveyWizardView.as_view()
+
+
+class BulkImportWizardView(View):
+    """Two-step workflow to import CSV data in bulk."""
+
+    template_upload = "pmksy/import_wizard_upload.html"
+    template_preview = "pmksy/import_wizard_preview.html"
+    session_key = "pmksy_bulk_import"
+
+    def get(self, request: HttpRequest, step: str | None = None) -> HttpResponse:
+        if step == "preview":
+            return self.render_preview(request)
+        return self.render_upload(request)
+
+    def post(self, request: HttpRequest, step: str | None = None) -> HttpResponse:
+        if step == "preview":
+            if "cancel" in request.POST:
+                self.clear_storage(request)
+                messages.info(request, "Bulk import cancelled.")
+                return redirect("pmksy:import")
+            if "confirm" in request.POST:
+                return self.perform_import(request)
+            return self.render_preview(request)
+        return self.handle_upload(request)
+
+    # ------------------------------------------------------------------
+    def render_upload(self, request: HttpRequest, form: django_forms.Form | None = None) -> HttpResponse:
+        form = form or forms.ImportUploadForm(choices=importers.target_choices())
+        context = {
+            "form": form,
+            "targets": importers.TARGET_LIST,
+        }
+        return render(request, self.template_upload, context)
+
+    def handle_upload(self, request: HttpRequest) -> HttpResponse:
+        form = forms.ImportUploadForm(request.POST or None, request.FILES or None, choices=importers.target_choices())
+        if not form.is_valid():
+            return self.render_upload(request, form)
+
+        target_key = form.cleaned_data["target"]
+        try:
+            target = importers.get_target(target_key)
+        except KeyError:
+            form.add_error("target", "Unknown dataset selected.")
+            return self.render_upload(request, form)
+
+        uploaded_file = form.cleaned_data["data_file"]
+        try:
+            parsed = importers.parse_uploaded_file(uploaded_file)
+        except ValueError as exc:
+            form.add_error("data_file", str(exc))
+            return self.render_upload(request, form)
+
+        storage_payload = {
+            "target": target.key,
+            "columns": parsed.columns,
+            "column_labels": parsed.original_headers,
+            "rows": [{"line": row.line_number, "values": dict(row.values)} for row in parsed.rows],
+        }
+        self.set_storage(request, storage_payload)
+        messages.info(request, "File parsed successfully. Review the preview before importing.")
+        return redirect("pmksy:import-preview")
+
+    def render_preview(self, request: HttpRequest) -> HttpResponse:
+        storage = self.get_storage(request)
+        if not storage:
+            messages.info(request, "Upload a CSV file to begin a bulk import.")
+            return redirect("pmksy:import")
+
+        target = importers.get_target(storage["target"])
+        context = self.build_preview_context(target, storage)
+        return render(request, self.template_preview, context)
+
+    def perform_import(self, request: HttpRequest) -> HttpResponse:
+        storage = self.get_storage(request)
+        if not storage:
+            messages.info(request, "Upload a CSV file to begin a bulk import.")
+            return redirect("pmksy:import")
+
+        target = importers.get_target(storage["target"])
+        context = self.build_preview_context(target, storage)
+        if not context["can_import"]:
+            messages.error(request, "Required columns are missing. Update the file and try again.")
+            return render(request, self.template_preview, context)
+
+        parsed_rows = [
+            importers.ParsedRow(line_number=row["line"], values=row["values"])
+            for row in storage["rows"]
+        ]
+        summary = importers.perform_import(target, parsed_rows)
+
+        if summary.created and not summary.error_count:
+            messages.success(request, f"Imported {summary.created} rows into {target.label}.")
+        elif summary.created:
+            messages.warning(
+                request,
+                f"Imported {summary.created} rows into {target.label} with {summary.error_count} errors.",
+            )
+        else:
+            messages.error(request, "No rows were imported. See the error details below.")
+
+        error_rows = [
+            {
+                "row_number": error.row_number,
+                "message": error.message,
+                "values": [
+                    (
+                        context["column_labels"].get(key, key),
+                        "—" if value in (None, "") else str(value),
+                    )
+                    for key, value in error.values.items()
+                ],
+            }
+            for error in summary.errors
+        ]
+
+        context.update(
+            {
+                "import_complete": True,
+                "summary": summary,
+                "error_rows": error_rows,
+            }
+        )
+        self.clear_storage(request)
+        return render(request, self.template_preview, context)
+
+    # ------------------------------------------------------------------
+    def build_preview_context(self, target: importers.ImportTarget, storage: Dict[str, object]) -> Dict[str, Any]:
+        columns: List[str] = list(storage.get("columns", []))
+        column_labels: Dict[str, str] = dict(storage.get("column_labels", {}))
+        rows: List[Dict[str, Any]] = list(storage.get("rows", []))
+
+        available_columns = set(columns)
+        target_columns = set(target.field_map.keys())
+        missing = sorted(target.required - available_columns)
+        recognized = [col for col in columns if col in target_columns]
+        unused = [col for col in columns if col not in target_columns]
+
+        preview_rows = rows[:10]
+        preview_headers = [
+            {
+                "key": col,
+                "label": column_labels.get(col, col),
+            }
+            for col in columns
+        ]
+        preview_table = [
+            [row["values"].get(col, "") for col in columns]
+            for row in preview_rows
+        ]
+
+        context: Dict[str, Any] = {
+            "target": target,
+            "row_count": len(rows),
+            "column_order": columns,
+            "column_labels": column_labels,
+            "preview_headers": preview_headers,
+            "preview_table": preview_table,
+            "recognized_columns": [
+                {
+                    "source": column_labels.get(col, col),
+                    "normalised": col,
+                    "model_field": target.field_map[col],
+                    "model_label": target.humanised_column(col),
+                }
+                for col in recognized
+            ],
+            "unused_columns": [column_labels.get(col, col) for col in unused],
+            "missing_columns": [target.humanised_column(col) for col in missing],
+            "required_columns": [target.humanised_column(col) for col in target.required],
+            "expected_columns": [
+                {
+                    "column": col,
+                    "label": target.humanised_column(col),
+                }
+                for col in target.expected_columns
+            ],
+            "can_import": len(rows) > 0 and not missing,
+            "error_rows": [],
+        }
+        return context
+
+    def get_storage(self, request: HttpRequest) -> Dict[str, Any] | None:
+        return request.session.get(self.session_key)
+
+    def set_storage(self, request: HttpRequest, payload: Dict[str, Any]) -> None:
+        request.session[self.session_key] = payload
+        request.session.modified = True
+
+    def clear_storage(self, request: HttpRequest) -> None:
+        request.session.pop(self.session_key, None)
+
+
+bulk_import_wizard_view = BulkImportWizardView.as_view()


### PR DESCRIPTION
## Summary
- implement a CSV powered bulk import wizard with preview, validation feedback and success summary
- add reusable import helper module that maps normalised headers to PMKSY models and converts data types
- refresh navigation, styles and documentation to highlight the new bulk upload workflow and add regression tests

## Testing
- python manage.py test *(fails: Django not installed in execution environment)*
- python -m compileall pmksy

------
https://chatgpt.com/codex/tasks/task_e_68ce50fcd0108326acf6d17963bab573