### PR TITLE
Implement survey wizard flow

### DIFF
--- a/pmksy_wizard/pmksy/templates/pmksy/base.html
+++ b/pmksy_wizard/pmksy/templates/pmksy/base.html
@@ -35,6 +35,13 @@
     </header>
     <main class="container">
 
+      {% if messages %}
+        <ul class="messages">
+          {% for message in messages %}
+            <li class="message {{ message.tags }}">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
 
       {% block content %}{% endblock %}
     </main>

--- a/pmksy_wizard/pmksy/tests.py
+++ b/pmksy_wizard/pmksy/tests.py
@@ -10,6 +10,168 @@ from django.urls import reverse
 from . import importers, models
 
 
+class SurveyWizardViewTests(TestCase):
+    """Ensure the survey wizard renders and persists data across steps."""
+
+    def management_form_data(self, prefix: str, total: int) -> dict[str, str]:
+        return {
+            f"{prefix}-TOTAL_FORMS": str(total),
+            f"{prefix}-INITIAL_FORMS": "0",
+            f"{prefix}-MIN_NUM_FORMS": "0",
+            f"{prefix}-MAX_NUM_FORMS": "1000",
+        }
+
+    def submit_farmer_step(self) -> None:
+        data = {
+            "name": "Asha",
+            "farming_experience_years": "0",
+            "family_males": "0",
+            "family_females": "0",
+            "family_children": "0",
+            "family_adult": "0",
+        }
+        response = self.client.post(reverse("pmksy:wizard"), data)
+        self.assertRedirects(response, reverse("pmksy:wizard-step", args=("land",)))
+
+    def test_get_home_renders_first_step(self) -> None:
+        response = self.client.get(reverse("pmksy:wizard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Farmer profile")
+        self.assertContains(response, "Step 1 of")
+
+    def test_post_farmer_creates_record_and_redirects(self) -> None:
+        self.submit_farmer_step()
+        self.assertEqual(models.Farmer.objects.count(), 1)
+        farmer = models.Farmer.objects.get()
+        self.assertEqual(farmer.name, "Asha")
+
+    def test_land_step_persists_related_records(self) -> None:
+        self.submit_farmer_step()
+
+        data: dict[str, str] = {}
+        data.update(self.management_form_data("land_holdings", 1))
+        data.update(
+            {
+                "land_holdings-0-category": "Irrigated",
+                "land_holdings-0-total_area_ha": "2.5",
+                "land_holdings-0-irrigated_area_ha": "",
+                "land_holdings-0-irrigation_source": "",
+                "land_holdings-0-irrigation_no": "",
+                "land_holdings-0-irrigation_latitude": "",
+                "land_holdings-0-irrigation_longitude": "",
+                "land_holdings-0-soil_details": "",
+            }
+        )
+        data.update(self.management_form_data("assets", 0))
+
+        response = self.client.post(reverse("pmksy:wizard-step", args=("land",)), data)
+        self.assertRedirects(response, reverse("pmksy:wizard-step", args=("production",)))
+
+        holding = models.LandHolding.objects.get()
+        self.assertEqual(holding.category, "Irrigated")
+        self.assertEqual(str(holding.farmer.farmer_id), str(models.Farmer.objects.get().farmer_id))
+
+    def test_complete_wizard_renders_success_template(self) -> None:
+        self.submit_farmer_step()
+
+        # Land & assets step
+        land_data: dict[str, str] = {}
+        land_data.update(self.management_form_data("land_holdings", 1))
+        land_data.update(
+            {
+                "land_holdings-0-category": "Rainfed",
+                "land_holdings-0-total_area_ha": "1.5",
+                "land_holdings-0-irrigated_area_ha": "",
+                "land_holdings-0-irrigation_source": "",
+                "land_holdings-0-irrigation_no": "",
+                "land_holdings-0-irrigation_latitude": "",
+                "land_holdings-0-irrigation_longitude": "",
+                "land_holdings-0-soil_details": "",
+            }
+        )
+        land_data.update(self.management_form_data("assets", 0))
+        self.client.post(reverse("pmksy:wizard-step", args=("land",)), land_data)
+
+        # Production step
+        production_data: dict[str, str] = {}
+        production_data.update(self.management_form_data("crop_history", 1))
+        production_data.update(
+            {
+                "crop_history-0-crop_name": "Wheat",
+                "crop_history-0-variety": "",
+                "crop_history-0-season": "",
+                "crop_history-0-area_ha": "",
+                "crop_history-0-production_kg": "",
+                "crop_history-0-sold_market_kg": "",
+                "crop_history-0-retained_seed_kg": "",
+                "crop_history-0-home_consumption_kg": "",
+            }
+        )
+        for prefix in [
+            "cost_cultivation",
+            "water_management",
+            "pest_disease",
+            "nutrient_management",
+            "income_crops",
+            "irrigated_rainfed",
+        ]:
+            production_data.update(self.management_form_data(prefix, 0))
+        self.client.post(reverse("pmksy:wizard-step", args=("production",)), production_data)
+
+        # Livelihoods step
+        livelihoods_data: dict[str, str] = {}
+        livelihoods_data.update(self.management_form_data("enterprises", 1))
+        livelihoods_data.update(
+            {
+                "enterprises-0-enterprise_type": "Dairy",
+                "enterprises-0-number": "1",
+                "enterprises-0-production": "",
+                "enterprises-0-home_consumption": "",
+                "enterprises-0-sold_market": "",
+                "enterprises-0-market_price": "",
+            }
+        )
+        for prefix in ["annual_income", "consumption", "market_price"]:
+            livelihoods_data.update(self.management_form_data(prefix, 0))
+        self.client.post(reverse("pmksy:wizard-step", args=("livelihoods",)), livelihoods_data)
+
+        # Resilience step with final save
+        resilience_data: dict[str, str] = {
+            "loan": "on",
+            "loan_purpose": "Crop inputs",
+        }
+        resilience_data.update(self.management_form_data("migration", 1))
+        resilience_data.update(
+            {
+                "migration-0-age_gender": "25M",
+                "migration-0-reason": "Seasonal work",
+                "migration-0-migration_type": "",
+                "migration-0-remittance": "",
+            }
+        )
+        resilience_data.update(self.management_form_data("adaptation", 1))
+        resilience_data.update(
+            {
+                "adaptation-0-strategy": "Drip irrigation",
+                "adaptation-0-aware": "on",
+                "adaptation-0-adopted": "",
+            }
+        )
+
+        response = self.client.post(
+            reverse("pmksy:wizard-step", args=("resilience",)), resilience_data
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pmksy/wizard_done.html")
+        self.assertContains(response, "Survey stored for")
+
+        farmer = models.Farmer.objects.get()
+        self.assertEqual(farmer.enterprises.count(), 1)
+        self.assertEqual(farmer.migration_records.count(), 1)
+        self.assertEqual(farmer.adaptation_strategies.count(), 1)
+        self.assertEqual(models.FinancialRecord.objects.filter(farmer=farmer).count(), 1)
+
+
 class BulkImportWizardTests(TestCase):
     """Integration tests covering the CSV import wizard endpoints."""
 


### PR DESCRIPTION
## Summary
- add request handlers and persistence helpers so the survey wizard renders, validates and saves each step before showing the completion summary
- add integration tests that exercise step navigation, saving related formsets and the end-to-end wizard flow
- surface Django messages in the base template so validation failures (e.g. missing import columns) are visible

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68ce758477d0832689dbd296abb6ef28